### PR TITLE
Fix all occurences of unneeded return statement.

### DIFF
--- a/src/lang/ast.rs
+++ b/src/lang/ast.rs
@@ -270,7 +270,7 @@ impl Node {
                             env.global_static_cmd(vec!["global", "types", "typeof"])?,
                             vec![r.generate_argument(env)?]),
                     "@" | "@@" => Ok(None),
-                    _ => return error("Unknown operator"),
+                    _ => error("Unknown operator"),
                 },
 
             Node::Cast(_, _) | Node::Glob(_) | Node::Label(_) | Node::Regex(_) | Node::Field(_) | Node::String(_) |

--- a/src/lang/binary.rs
+++ b/src/lang/binary.rs
@@ -123,7 +123,7 @@ impl dyn BinaryReader {
     }
 
     pub fn vec(vec: &Vec<u8>) -> Box<dyn BinaryReader + Send + Sync> {
-        return Box::from(VecReader { vec: vec.clone(), offset: 0 });
+        Box::from(VecReader { vec: vec.clone(), offset: 0 })
     }
 }
 

--- a/src/lang/command/mod.rs
+++ b/src/lang/command/mod.rs
@@ -184,7 +184,7 @@ impl Help for SimpleCommand {
 
 impl std::cmp::PartialEq for SimpleCommand {
     fn eq(&self, _other: &SimpleCommand) -> bool {
-        return false;
+        false
     }
 }
 
@@ -254,7 +254,7 @@ impl Help for ConditionCommand {
 
 impl std::cmp::PartialEq for ConditionCommand {
     fn eq(&self, _other: &ConditionCommand) -> bool {
-        return false;
+        false
     }
 }
 

--- a/src/lang/errors.rs
+++ b/src/lang/errors.rs
@@ -20,38 +20,38 @@ pub struct CrushError {
 pub type CrushResult<T> = Result<T, CrushError>;
 
 pub fn block_error<T>() -> Result<T, CrushError> {
-    return Err(CrushError {
+    Err(CrushError {
         message: String::from("Internal error: Tried to call blocking code in a thread that may not block"),
         kind: BlockError,
-    });
+    })
 }
 
 pub fn send_error<T>() -> Result<T, CrushError> {
-    return Err(CrushError {
+    Err(CrushError {
         message: String::from("Tried to send data to a command that is no longer listening. This is almost normal behaviour and can be safely ignored."),
         kind: SendError,
-    });
+    })
 }
 
 pub fn argument_error<T>(message: &str) -> Result<T, CrushError> {
-    return Err(CrushError {
+    Err(CrushError {
         message: String::from(message),
         kind: InvalidArgument,
-    });
+    })
 }
 
 pub fn data_error<T>(message: &str) -> Result<T, CrushError> {
-    return Err(CrushError {
+    Err(CrushError {
         message: String::from(message),
         kind: InvalidData,
-    });
+    })
 }
 
 pub fn error<T>(message: &str) -> Result<T, CrushError> {
-    return Err(CrushError {
+    Err(CrushError {
         message: String::from(message),
         kind: GenericError,
-    });
+    })
 }
 
 pub fn to_crush_error<T, E: Error>(result: Result<T, E>) -> Result<T, CrushError> {

--- a/src/lang/job.rs
+++ b/src/lang/job.rs
@@ -12,7 +12,7 @@ pub enum JobJoinHandle {
 
 impl JobJoinHandle {
     pub fn join(self, printer: &Printer) {
-        return match self {
+        match self {
             JobJoinHandle::Async(a) => match a.join() {
                 Ok(_) => {},
                 Err(_) => printer.error("Unknown error while waiting for command to exit"),
@@ -22,7 +22,7 @@ impl JobJoinHandle {
                     j.join(printer);
                 }
             }
-        };
+        }
     }
 }
 

--- a/src/lang/pretty_printer.rs
+++ b/src/lang/pretty_printer.rs
@@ -83,7 +83,7 @@ fn is_text(buff: &[u8]) -> bool {
             c += 1;
         }
     }
-    return (c as f64) / (buff.len() as f64) > 0.8;
+    (c as f64) / (buff.len() as f64) > 0.8
 }
 
 impl PrettyPrinter {

--- a/src/lang/scope.rs
+++ b/src/lang/scope.rs
@@ -59,7 +59,7 @@ struct ScopeData {
 
 impl ScopeData {
     fn anonymous(parent_scope: Option<Scope>, calling_scope: Option<Scope>, is_loop: bool) -> ScopeData {
-        return ScopeData {
+        ScopeData {
             parent_scope,
             calling_scope,
             is_loop,
@@ -68,11 +68,11 @@ impl ScopeData {
             is_stopped: false,
             is_readonly: false,
             name: None,
-        };
+        }
     }
 
     fn named(parent_scope: Option<Scope>, calling_scope: Option<Scope>, is_loop: bool, name: &str) -> ScopeData {
-        return ScopeData {
+        ScopeData {
             parent_scope,
             calling_scope,
             is_loop,
@@ -81,7 +81,7 @@ impl ScopeData {
             is_stopped: false,
             is_readonly: false,
             name: Some(Box::from(name)),
-        };
+        }
     }
 }
 
@@ -314,7 +314,7 @@ impl Scope {
 
     pub fn remove_str(&self, name: &str) -> Option<Value> {
         let n = &name.split(':').map(|e: &str| Box::from(e)).collect::<Vec<Box<str>>>()[..];
-        return self.remove(n);
+        self.remove(n)
     }
 
     pub fn remove(&self, name: &[Box<str>]) -> Option<Value> {

--- a/src/lang/table.rs
+++ b/src/lang/table.rs
@@ -53,7 +53,7 @@ impl Readable for TableReader {
             return error("EOF");
         }
         self.idx += 1;
-        return Ok(self.rows.rows.replace(self.idx - 1, Row::new(vec![Value::Integer(0)])));
+        Ok(self.rows.rows.replace(self.idx - 1, Row::new(vec![Value::Integer(0)])))
     }
 
     fn types(&self) -> &Vec<ColumnType> {

--- a/src/lang/value/mod.rs
+++ b/src/lang/value/mod.rs
@@ -57,7 +57,7 @@ pub enum Value {
 
 impl ToString for Value {
     fn to_string(&self) -> String {
-        return match self {
+        match self {
             Value::String(val) => val.to_string(),
             Value::Integer(val) => val.to_string(),
             Value::Time(val) => val.format("%Y-%m-%d %H:%M:%S %z").to_string(),
@@ -75,7 +75,7 @@ impl ToString for Value {
             Value::Type(t) => t.to_string(),
             Value::Struct(s) => s.to_string(),
             _ => format!("<{}>", self.value_type().to_string()),
-        };
+        }
     }
 }
 
@@ -128,15 +128,15 @@ impl Value {
     pub fn path(&self, name: &str) -> Option<Value> {
         match self {
             Value::File(s) => Some(Value::File(s.join(name).into_boxed_path())),
-            _ => return None,
+            _ => None,
         }
     }
 
     pub fn alignment(&self) -> Alignment {
-        return match self {
+        match self {
             Value::Time(_) | Value::Duration(_) | Value::Integer(_) => Alignment::Right,
             _ => Alignment::Left,
-        };
+        }
     }
 
     pub fn empty_table_stream() -> Value {
@@ -345,7 +345,7 @@ fn file_result_compare(f1: &Path, f2: &Path) -> bool {
 
 impl std::cmp::PartialEq for Value {
     fn eq(&self, other: &Value) -> bool {
-        return match (self, other) {
+        match (self, other) {
             (Value::String(val1), Value::String(val2)) => val1 == val2,
             (Value::Integer(val1), Value::Integer(val2)) => val1 == val2,
             (Value::Time(val1), Value::Time(val2)) => val1 == val2,
@@ -365,7 +365,7 @@ impl std::cmp::PartialEq for Value {
             (Value::Float(val1), Value::Float(val2)) => val1 == val2,
             (Value::Binary(val1), Value::Binary(val2)) => val1 == val2,
             _ => false,
-        };
+        }
     }
 }
 

--- a/src/lib/input/http.rs
+++ b/src/lib/input/http.rs
@@ -51,13 +51,13 @@ fn parse(mut arguments: Vec<Argument>) -> CrushResult<Config> {
             _ => { return argument_error("Unknown argument"); }
         }
     }
-    return Ok(Config {
+    Ok(Config {
         url: demand(url, "url")?.to_string(),
         method,
         headers,
         cache,
         body: form,
-    });
+    })
 }
 
 pub fn perform(context: ExecutionContext) -> CrushResult<()> {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -29,5 +29,5 @@ pub fn declare(root: &Scope) -> CrushResult<()> {
     constants::declare(root)?;
     math::declare(root)?;
     root.readonly();
-    return Ok(());
+    Ok(())
 }

--- a/src/lib/stream/count.rs
+++ b/src/lib/stream/count.rs
@@ -11,7 +11,7 @@ fn count_rows(mut s: Box<dyn Readable>) -> Value {
             Err(_) => break,
         }
     }
-    return Value::Integer(res);
+    Value::Integer(res)
 }
 
 pub fn perform(context: ExecutionContext) -> CrushResult<()> {

--- a/src/lib/stream/group.rs
+++ b/src/lib/stream/group.rs
@@ -70,7 +70,7 @@ pub fn run(
             Err(_) => break,
         }
     }
-    return Ok(());
+    Ok(())
 }
 
 pub fn perform(context: ExecutionContext) -> CrushResult<()> {

--- a/src/lib/stream/head.rs
+++ b/src/lib/stream/head.rs
@@ -21,7 +21,7 @@ pub fn run(
             Err(_) => break,
         }
     }
-    return Ok(());
+    Ok(())
 }
 
 pub fn perform(mut context: ExecutionContext) -> CrushResult<()> {

--- a/src/lib/stream/join.rs
+++ b/src/lib/stream/join.rs
@@ -55,7 +55,7 @@ fn scan_table(table: &str, column: &str, input_type: &Vec<ColumnType>) -> Result
 fn parse(input_type: &Vec<ColumnType>, arguments: Vec<Argument>) -> Result<Config, CrushError> {
     arguments.check_len(2)?;
 
-    return match (&arguments[0].value, &arguments[1].value) {
+    match (&arguments[0].value, &arguments[1].value) {
         (Value::Field(l), Value::Field(r)) => {
 
             let config = match (l.len(), r.len()) {
@@ -101,7 +101,7 @@ fn parse(input_type: &Vec<ColumnType>, arguments: Vec<Argument>) -> Result<Confi
             Ok(config)
         }
         _ => argument_error("Expected arguments like %table1.col == %table2.col"),
-    };
+    }
 }
 
 fn combine(mut l: Row, r: Row, cfg: &Config) -> Row {
@@ -110,7 +110,7 @@ fn combine(mut l: Row, r: Row, cfg: &Config) -> Row {
             l.push(c);
         }
     }
-    return l;
+    l
 }
 
 fn do_join(cfg: &Config, l: &mut dyn Readable, r: &mut dyn Readable, output: &OutputStream) -> CrushResult<()> {

--- a/src/lib/stream/sort.rs
+++ b/src/lib/stream/sort.rs
@@ -50,7 +50,7 @@ pub fn run(config: Config, input: &mut dyn Readable, output: OutputStream) -> Cr
         output.send(row)?;
     }
 
-    return Ok(());
+    Ok(())
 }
 
 pub fn perform(context: ExecutionContext) -> CrushResult<()> {

--- a/src/lib/stream/tail.rs
+++ b/src/lib/stream/tail.rs
@@ -28,7 +28,7 @@ pub fn run(
             }
         }
     }
-    return Ok(());
+    Ok(())
 }
 
 pub fn perform(mut context: ExecutionContext) -> CrushResult<()> {

--- a/src/lib/stream/uniq.rs
+++ b/src/lib/stream/uniq.rs
@@ -62,7 +62,7 @@ pub fn run(
             }
         }
     }
-    return Ok(());
+    Ok(())
 }
 
 pub fn perform(context: ExecutionContext) -> CrushResult<()> {

--- a/src/lib/stream/where.rs
+++ b/src/lib/stream/where.rs
@@ -49,7 +49,7 @@ pub fn run(condition: Box<dyn CrushCommand + Send + Sync>, input: &mut dyn Reada
             Err(_) => break,
         }
     }
-    return Ok(());
+    Ok(())
 }
 
 pub fn parse(_input_type: &Vec<ColumnType>,

--- a/src/lib/stream/zip.rs
+++ b/src/lib/stream/zip.rs
@@ -18,7 +18,7 @@ pub fn run(input1: &mut dyn Readable, input2: &mut dyn Readable, sender: ValueSe
             _ => break,
         }
     }
-    return Ok(());
+    Ok(())
 }
 
 pub fn perform(mut context: ExecutionContext) -> CrushResult<()> {

--- a/src/lib/traversal/find.rs
+++ b/src/lib/traversal/find.rs
@@ -110,7 +110,7 @@ pub fn run(mut config: Config) -> CrushResult<()> {
         let dir = q.pop_front().unwrap();
         let _ = run_for_single_directory_or_file(dir, &users, config.recursive, &mut q, &mut config.output);
     }
-    return Ok(());
+    Ok(())
 }
 
 pub struct Config {


### PR DESCRIPTION
Currently, running `cargo clippy` produces 352 warnings.
This commit fixes 21 of them by removing all return statement where the function can also implicitly return by using an expression instead.