### PR TITLE
Add support for npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 /target
 **/*.rs.bk
 .*
+!.npmignore
 *.iml
 src/lang/serialization/model.rs

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 /target
 **/*.rs.bk
 .*
-!.npmignore
 *.iml
 src/lang/serialization/model.rs

--- a/build.js
+++ b/build.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var child_process = require('child_process');
+var exec = child_process.exec;
+var execSync = child_process.execSync;
+var readline = require('readline').createInterface({
+	input: process.stdin,
+	output: process.stdout
+});
+
+function isWindows() {
+	return process.platform === 'win32';
+}
+
+function installRust() {
+	switch (process.platform) {
+		case 'darwin':
+		case 'linux':
+			execSync('curl --proto \'=https\' --tlsv1.2 https://sh.rustup.rs -sSf | sh');
+		case 'win32':
+			execSync('start https://www.rust-lang.org/tools/install');
+	}
+}
+
+// ------- REMOVE THIS WHEN SUPPORT FOR WINDOWS -----------
+if (isWindows()) {
+	process.stdout.write('\n' + '-'.repeat(29) + '\nWindows is not supported yet.\n' + '-'.repeat(29) + '\n\n\n');
+	process.exit(1);
+}
+// --------------------------------------------------------
+
+new Promise(function (res) {
+	try {
+		var child = exec('cargo build', { cwd: __dirname });
+		child.stdout.pipe(process.stdout);
+		child.stderr.pipe(process.stderr);
+		child.on('close', function (code) {
+			res(code);
+		});
+	} catch {
+		res(1);
+	}
+}).then(code => {
+	if (code !== 1) {
+		process.stdout.write('\n\nBuild program did not successfully finish.\nDid you forget to install rust/cargo?\n');
+		var askInstall = function () {
+			readline.question('\nDo you want to install rust? (y/n) ', function (res) {
+				console.log(res);
+				if (res.toLowerCase().trim() === 'y') {
+					installRust();
+				} else if (res.toLowerCase().trim() === 'n') {
+					process.exit();
+				} else {
+					askInstall();
+				}
+				readline.close();
+			});
+		}
+		askInstall();
+	}
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "crush",
+	"version": "0.1.0",
+	"description": "Crush is an attempt to make a command line shell that is also a powerful modern programming language.",
+	"main": "index.js",
+	"directories": {
+		"doc": "docs",
+		"test": "tests"
+	},
+	"scripts": {
+		"postinstall": "node build.js"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/liljencrantz/crush.git"
+	},
+	"author": "liljencrantz",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/liljencrantz/crush/issues"
+	},
+	"homepage": "https://github.com/liljencrantz/crush#readme"
+}


### PR DESCRIPTION
## Changes
-  Changed to ignore ignore (not ignore) `.npmignore` in `.gitignore`. (`!.gitignore`)
- Added .npmignore
- Added build.js
- Added package.json

## File purposes
- **.npmignore** - The name says it all. This file includes all glob patterns to be excluded when published at npm.
- **build.js** - JavaScript file to run `cargo build`.
- **package.json** - Information for npm required to publish at npm.

## Requirements
Have a recent installation of [nodejs](https://nodejs.org/en/), including npm and fundamental JSON knowledge.

## Publishing
Change the version property in the `package.json` file to the version and run `npm publish`.

## Big [oof](https://www.urbandictionary.com/define.php?term=oof)
The name crush is taken. There are two options;

1. **Get the name**
    The crush package on npm has 0 weekly downloads and hasn't been updated for six years; therefore, it could be possible to get the name anyways by contacting the owner or npm.

2. **Choose another name**
    For example, you could name the package: `crush-term`, `crush-cli`, `ccrush`,[ `crush-shell`](https://github.com/liljencrantz/crush/pull/27#issuecomment-703733006) or `cru-sh`.

After choosing the name change the `name`  property in `package.json`.

## And also...
When if support for windows, remove this part of `build.js`:
```
// ------- REMOVE THIS WHEN SUPPORT FOR WINDOWS -----------
if (isWindows()) {
	process.stdout.write('\n' + '-'.repeat(29) + '\nWindows is not supported yet.\n' + '-'.repeat(29) + '\n\n\n');
	process.exit(1);
}
// --------------------------------------------------------
```