### PR TITLE
Remove unused imports and globally silence "unused" warnings

### DIFF
--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -795,7 +795,8 @@ fn signature_real(metadata: TokenStream, input: TokenStream) -> SignatureResult<
 
             let handler = quote! {
 
-            #[allow(unused_parens)] // TODO: don't emit unnecessary parenthesis in the first place
+                // TODO: don't emit unnecessary parenthesis in the first place
+            #[allow(unused_parens)]
             impl #struct_name {
                 pub fn declare(env: &mut crate::lang::data::scope::ScopeLoader) -> crate::lang::errors::CrushResult <()> {
                     env.declare_command(

--- a/src/lang/completion/mod.rs
+++ b/src/lang/completion/mod.rs
@@ -1,8 +1,7 @@
 use crate::lang::data::scope::Scope;
-use crate::lang::errors::{CrushResult, error, mandate};
+use crate::lang::errors::{CrushResult, mandate};
 use crate::lang::argument::ArgumentDefinition;
-use crate::lang::value::{Field, ValueType, Value};
-use crate::lang::command::Command;
+use crate::lang::value::{ValueType, Value};
 use crate::util::directory_lister::DirectoryLister;
 use std::path::PathBuf;
 use crate::lang::completion::parse::{ParseResult, CompletionCommand, LastArgument, parse};
@@ -53,8 +52,8 @@ impl ParseState {
     }
 }
 
-fn complete_cmd(cmd: Option<String>, args: Vec<ArgumentDefinition>, arg: TokenNode, scope: Scope) -> CrushResult<Vec<Completion>> {
-    let mut map = scope.dump()?;
+fn complete_cmd(_cmd: Option<String>, _args: Vec<ArgumentDefinition>, arg: TokenNode, scope: Scope) -> CrushResult<Vec<Completion>> {
+    let map = scope.dump()?;
     let mut res = Vec::new();
 
     for name in map.keys() {
@@ -83,7 +82,7 @@ fn complete_value(value: Value, prefix: &[String], t: ValueType, cursor: usize, 
     }
 }
 
-fn complete_file(lister: &impl DirectoryLister, prefix: impl Into<PathBuf>, t: ValueType, cursor: usize, out: &mut Vec<Completion>) -> CrushResult<()> {
+fn complete_file(lister: &impl DirectoryLister, prefix: impl Into<PathBuf>, _t: ValueType, cursor: usize, out: &mut Vec<Completion>) -> CrushResult<()> {
     let prefix = prefix.into();
 
     let prefix_str = mandate(prefix.components().last(), "Invalid file for completion")?.as_os_str().to_str().unwrap();

--- a/src/lang/serialization/tracked_string_serializer.rs
+++ b/src/lang/serialization/tracked_string_serializer.rs
@@ -3,7 +3,6 @@ use crate::lang::serialization::model::{element, Element};
 use crate::lang::serialization::model;
 
 use crate::lang::serialization::{DeserializationState, Serializable, SerializationState};
-use std::collections::hash_map::Entry;
 use crate::lang::ast::{TrackedString, Location};
 
 impl Serializable<TrackedString> for TrackedString {

--- a/src/lang/value/mod.rs
+++ b/src/lang/value/mod.rs
@@ -135,7 +135,7 @@ impl Value {
         let mut res = Vec::new();
         match self {
             Value::Struct(s) => res.append(&mut s.keys()),
-            Value::Scope(scope) => res.append(&mut scope.dump().unwrap().iter().map(|(k, v)| k.to_string()).collect()),
+            Value::Scope(scope) => res.append(&mut scope.dump().unwrap().iter().map(|(k, _v)| k.to_string()).collect()),
             Value::Type(t) => add_keys(t.fields(), &mut res),
             _ => add_keys(self.value_type().fields(), &mut res),
         }

--- a/src/lib/dbus.rs
+++ b/src/lib/dbus.rs
@@ -1,3 +1,6 @@
+// TODO: remove unused allowance
+#![allow(unused)]
+
 use crate::lang::argument::{column_names, Argument};
 use crate::lang::command::CrushCommand;
 use crate::lang::command::OutputType::*;
@@ -422,7 +425,7 @@ impl DBusArgument {
             }
             DBusType::Array(_) => {}
             DBusType::Variant => {}
-            DBusType::DictEntry{ key_type, value_type } => {}
+            DBusType::DictEntry{ .. } => {}
             DBusType::UnixFd => {}
             DBusType::Struct(_) => {}
             DBusType::ObjectPath => {}

--- a/src/lib/fs/mod.rs
+++ b/src/lib/fs/mod.rs
@@ -1,5 +1,5 @@
 use crate::lang::command::OutputType::Known;
-use crate::lang::errors::{argument_error, to_crush_error, CrushResult};
+use crate::lang::errors::{to_crush_error, CrushResult};
 use crate::lang::execution_context::CommandContext;
 use crate::lang::help::Help;
 use crate::lang::printer::Printer;
@@ -77,7 +77,7 @@ pub struct HelpSignature {
     topic: Option<Value>,
 }
 
-pub fn help(mut context: CommandContext) -> CrushResult<()> {
+pub fn help(context: CommandContext) -> CrushResult<()> {
     let cfg: HelpSignature = HelpSignature::parse(context.arguments, &context.printer)?;
     match cfg.topic {
         None => {
@@ -107,7 +107,6 @@ members of a value, write "dir <value>".
             }
             context.output.send(Value::Empty())
         }
-        _ => argument_error("The help command expects at most one argument"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+// TODO: There are to many unused parts in code.
+// This disables warnings but a proper fix would be to remove or use them.
+#![allow(unused)]
+
 #[macro_use]
 extern crate lalrpop_util;
 

--- a/src/util/directory_lister.rs
+++ b/src/util/directory_lister.rs
@@ -142,7 +142,7 @@ impl DirectoryLister for FakeDirectoryLister {
     type DirectoryIter = FakeIter;
 
     fn list(&self, path: impl Into<PathBuf>) -> CrushResult<Self::DirectoryIter> {
-        let mut g = path.into();
+        let g = path.into();
         let path = if g.is_relative() {
             self.cwd.join(&g)
         } else {

--- a/src/util/glob.rs
+++ b/src/util/glob.rs
@@ -1,7 +1,5 @@
-use crate::lang::errors::{argument_error, to_crush_error, CrushResult, data_error};
+use crate::lang::errors::{argument_error, CrushResult, data_error};
 use std::collections::VecDeque;
-use std::fs::read_dir;
-use std::io;
 use std::path::{Path, PathBuf};
 use std::fmt::{Display, Formatter};
 use crate::util::directory_lister::{directory_lister, DirectoryLister};


### PR DESCRIPTION
rustc warnings are quite useful, but right now during active
development phase, there are to many "unused" warning. This PR silence
them globally in hope that eventually they will be removed. Thus all
the other warnings can be seen and acted upon.